### PR TITLE
 Endpoint organization

### DIFF
--- a/OngProject/Controllers/OrganizationController.cs
+++ b/OngProject/Controllers/OrganizationController.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using OngProject.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+// For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace OngProject.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class OrganizationController : ControllerBase
+    {
+        //ORGANIZACION INYECCION
+
+        //CONTRUCTOR
+
+
+        //GET api/<OrganizationController>/5
+        //[HttpGet]
+        //public async Task<ActionResult<Organization>> GetById(int id)
+        //{
+        //    try
+        //    {
+        //        var organization = await _organizationService.GetById(id);
+
+        //        if (organization.Id == id)
+        //        {
+        //            return organization;
+        //        }
+        //        else
+        //        {
+        //            return StatusCode(404);
+        //        }
+        //    }
+        //    catch (System.Exception ex)
+        //    {
+        //        string error = ex.Message;
+        //        return NoContent();
+        //    }
+        //}
+    }
+}

--- a/OngProject/Models/Organization.cs
+++ b/OngProject/Models/Organization.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace OngProject.Models
+{
+    public class Organization
+    {
+        public int Id { get; set; }
+
+
+        [Required]
+        public string Name { get; set; }
+        [Required]
+        public int Image { get; set; }
+        [Required]
+        public string Address { get; set; }
+
+        public int Phone { get; set; }
+    }
+}


### PR DESCRIPTION
Se crea el controllador de Organization, en este caso no se utilizan ViewModels por un error al tratar de crear la carpeta y porque se desconoce la entidad "original" de Organization, se sube el codigo comentado para evitar conflictos hasta saber mas datos de la entidad. 