### PR TITLE
Creacion Seed Data Members y Users

### DIFF
--- a/OngProject/Data/MembersSeedData.cs
+++ b/OngProject/Data/MembersSeedData.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.EntityFrameworkCore;
+using OngProject.Models;
+
+namespace OngProject.Data
+{
+    public static class MembersSeedData
+    {
+        public static void MembersSeed(this ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<Member>().HasData(
+                new Member
+                {
+                    Id = 1,
+                    Name = "María Irola",
+                    Description = "Presidenta",
+                    Image = "Empty",
+                    FacebookUrl = "www.Facebook.com/MariaIrola",
+                    InstagramUrl = "www.Instagram.com/MariaIrola",
+                    LinkedinUrl = "www.Linkedin.com/MariaIrola",
+                    DeletedAt = null                   
+                },
+                new Member
+                {
+                    Id = 2,
+                    Name = "Marita Gomez",
+                    Description = "Fundadora",
+                    Image = "Empty",
+                    FacebookUrl = "www.Facebook.com/MaritaGomez",
+                    InstagramUrl = "www.Instagram.com/MaritaGomez",
+                    LinkedinUrl = "www.Linkedin.com/MaritaGomez",
+                    DeletedAt = null
+                },
+                new Member
+                {
+                    Id = 3,
+                    Name = "Miriam Rodriguez",
+                    Description = "Terapista Ocupacional",
+                    Image = "Empty",
+                    FacebookUrl = "www.Facebook.com/MiriamRodriguez",
+                    InstagramUrl = "www.Instagram.com/MiriamRodriguez",
+                    LinkedinUrl = "www.Linkedin.com/MiriamRodriguez",
+                    DeletedAt = null
+                },
+                new Member
+                {
+                    Id = 4,
+                    Name = "Cecilia Mendez",
+                    Description = "Psicopedagoga",
+                    Image = "Empty",
+                    FacebookUrl = "www.Facebook.com/CeciliaMendez",
+                    InstagramUrl = "www.Instagram.com/CeciliaMendez",
+                    LinkedinUrl = "www.Linkedin.com/CeciliaMendez",
+                    DeletedAt = null
+                },
+                new Member
+                {
+                    Id = 5,
+                    Name = "Mario Fuentes",
+                    Description = "Psicólogo",
+                    Image = "Empty",
+                    FacebookUrl = "www.Facebook.com/MarioFuentes",
+                    InstagramUrl = "www.Instagram.com/MarioFuentes",
+                    LinkedinUrl = "www.Linkedin.com/MarioFuentes",
+                    DeletedAt = null
+                },
+                new Member
+                {
+                    Id = 6,
+                    Name = "Rodrigo Fuente",
+                    Description = "Contador",
+                    Image = "Empty",
+                    FacebookUrl = "www.Facebook.com/RodrigoFuente",
+                    InstagramUrl = "www.Instagram.com/RodrigoFuente",
+                    LinkedinUrl = "www.Linkedin.com/RodrigoFuente",
+                    DeletedAt = null
+                },
+                new Member
+                {
+                    Id = 7,
+                    Name = "Maria Garcia",
+                    Description = "Profesora de Artes Dramáticas",
+                    Image = "Empty",
+                    FacebookUrl = "www.Facebook.com/MariaGarcia",
+                    InstagramUrl = "www.Instagram.com/MariaGarcia",
+                    LinkedinUrl = "www.Linkedin.com/MariaGarcia",
+                    DeletedAt = null
+                },
+                new Member
+                {
+                    Id = 2,
+                    Name = "Marco Fernandez",
+                    Description = "Profesor de Educación Física",
+                    Image = "Empty",
+                    FacebookUrl = "www.Facebook.com/MarcoFernandez",
+                    InstagramUrl = "www.Instagram.com/MarcoFernandez",
+                    LinkedinUrl = "www.Linkedin.com/MarcoFernandez",
+                    DeletedAt = null
+                });
+        }
+    }
+}

--- a/OngProject/Data/ONGDBContext.cs
+++ b/OngProject/Data/ONGDBContext.cs
@@ -32,6 +32,8 @@ namespace OngProject.Data
             base.OnModelCreating(modelBuilder);
 
             modelBuilder.Seed();
+            modelBuilder.UserSeed();
+            modelBuilder.MembersSeed();
         }
         public DbSet<Category> Categories { get; set; }
         public DbSet<User> Users { get; set; }

--- a/OngProject/Data/UserSeedData.cs
+++ b/OngProject/Data/UserSeedData.cs
@@ -1,9 +1,13 @@
-# base-ong-server-csharp
-Repositorio base para Caso ONG de C#
-tratando de cambiar el nombre de la branch
+﻿using Microsoft.EntityFrameworkCore;
+using OngProject.Models;
 
-
-Usuarios Estandar y Usuarios Regulares modelo:
+namespace OngProject.Data
+{
+    public static class UserSeedData
+    {
+        public static void UserSeed(this ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<User>().HasData(
                 new User
                 {
                     IdUser = 1,                    
@@ -324,5 +328,7 @@ Usuarios Estandar y Usuarios Regulares modelo:
                 }
 
 
-
-
+                );
+        }
+    }
+}


### PR DESCRIPTION
Crear Model Seed Data de Usuarios OT82:
se creó un seeder para popular la base de datos con Usuarios para realizar pruebas. 10 Usuarios estándar y 10 regulares. Posteriormente, se agregaron los datos de los mismos en el README.md para permitir que los otros Miembros puedan utilizarlos

Crear Model Seed Data de Miembros OT85:
En base a los datos existentes de Miembros en el caso ONG, se creó un seeder que permite popular estos datos en la base.